### PR TITLE
Add clipboard history feature

### DIFF
--- a/packages/desktop/src/overlay.html
+++ b/packages/desktop/src/overlay.html
@@ -45,8 +45,11 @@
   </head>
   <body>
     <div id="container">
-      <input id="search" type="text" placeholder="Search snippets" />
+      <input id="search" type="text" placeholder="Search" />
+      <h3>Snippets</h3>
       <ul id="results"></ul>
+      <h3>Paste from History</h3>
+      <ul id="history"></ul>
       <div id="chain-runner" style="display:none"></div>
     </div>
     <script src="overlay.js"></script>

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -13,6 +13,9 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('update-chain', id, name, nodes),
   deleteChain: (id: number) => ipcRenderer.invoke('delete-chain', id),
   getChainByName: (name: string) => ipcRenderer.invoke('get-chain-by-name', name),
+  getClipboardHistory: () => ipcRenderer.invoke('get-clipboard-history'),
+  pinClipboardItem: (id: string, pinned: boolean) =>
+    ipcRenderer.invoke('pin-clipboard-item', id, pinned),
   hideOverlay: () => ipcRenderer.send('hide-overlay'),
   getErrorLog: () => ipcRenderer.invoke('get-error-log'),
   exportDiagnostics: () => ipcRenderer.invoke('export-diagnostics'),

--- a/packages/desktop/src/services/clipboard.ts
+++ b/packages/desktop/src/services/clipboard.ts
@@ -1,0 +1,28 @@
+import { clipboard } from 'electron';
+import * as db from '../db';
+import { logger } from '../logger';
+
+let last = '';
+let interval: NodeJS.Timeout | null = null;
+
+export function startClipboardMonitor() {
+  if (interval) return;
+  interval = setInterval(() => {
+    try {
+      const text = clipboard.readText();
+      if (text && text !== last) {
+        db.addClipboardEntry(text);
+        last = text;
+      }
+    } catch (err) {
+      logger.error(`clipboard monitor error: ${err}`);
+    }
+  }, 1000);
+}
+
+export function stopClipboardMonitor() {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+  }
+}

--- a/packages/desktop/src/test/clipboard.test.ts
+++ b/packages/desktop/src/test/clipboard.test.ts
@@ -1,0 +1,29 @@
+import { strict as assert } from 'assert';
+import { join } from 'path';
+import { existsSync, unlinkSync } from 'fs';
+import * as db from '../db';
+
+const DB_PATH = join(__dirname, '..', 'snippets.db');
+if (existsSync(DB_PATH)) unlinkSync(DB_PATH);
+
+db.init();
+
+db.addClipboardEntry('one');
+db.addClipboardEntry('one'); // duplicate should not add new
+let history = db.getClipboardHistory();
+assert.equal(history.length, 1);
+assert.equal(history[0]!.content, 'one');
+
+// add multiple items
+for (let i = 0; i < 25; i++) {
+  db.addClipboardEntry(`item${i}`);
+}
+
+history = db.getClipboardHistory();
+const pinnedCount = history.filter(h => h.pinned).length;
+assert(history.length - pinnedCount <= 20);
+
+db.pinClipboardItem(history[0]!.id, true);
+assert.equal(db.getClipboardHistory()[0]!.pinned, 1);
+
+export {};

--- a/packages/desktop/src/types.ts
+++ b/packages/desktop/src/types.ts
@@ -8,6 +8,8 @@ export interface SnippetApi {
   updateChain?(id: number, name: string, nodes: unknown[]): Promise<any>;
   deleteChain(id: number): Promise<any>;
   getChainByName(name: string): Promise<any>;
+  getClipboardHistory(): Promise<{ id: string; content: string; timestamp: number; pinned: number }[]>;
+  pinClipboardItem(id: string, pinned: boolean): Promise<any>;
   hideOverlay(): void;
   getErrorLog(): Promise<string>;
   exportDiagnostics(): Promise<string>;


### PR DESCRIPTION
## Summary
- implement clipboard_history table and db helpers
- monitor clipboard changes in new clipboard service
- expose clipboard history API via IPC and preload
- extend overlay UI with "Paste from History" section
- add tests for clipboard database logic

## Testing
- `pnpm test` *(fails: ENOTCACHED prebuildify)*
- `pnpm --filter @snipflow/desktop run build --if-present` *(fails: ENOTCACHED prebuildify)*