### PR TITLE
Enhance overlay interactions and settings

### DIFF
--- a/packages/desktop/src/autopaste.ts
+++ b/packages/desktop/src/autopaste.ts
@@ -1,0 +1,16 @@
+import { execSync } from 'child_process';
+import { logger } from './logger';
+
+export function pasteClipboard(): void {
+  try {
+    if (process.platform === 'darwin') {
+      execSync('osascript -e "tell application \"System Events\" to keystroke \"v\" using command down"');
+    } else if (process.platform === 'win32') {
+      execSync('powershell -command "$wshell = New-Object -ComObject wscript.shell; $wshell.SendKeys(\"^v\")"');
+    } else {
+      execSync('xdotool key --clearmodifiers ctrl+v');
+    }
+  } catch (err) {
+    logger.error(`autopaste error: ${err}`);
+  }
+}

--- a/packages/desktop/src/overlay.html
+++ b/packages/desktop/src/overlay.html
@@ -4,20 +4,33 @@
     <meta charset="UTF-8" />
     <title>SnipFlow Overlay</title>
     <style>
+      :root {
+        --bg: rgba(30, 30, 30, 0.9);
+        --text: #fff;
+        --hover: rgba(255, 255, 255, 0.1);
+      }
+      body.light {
+        --bg: rgba(255, 255, 255, 0.95);
+        --text: #222;
+        --hover: rgba(0, 0, 0, 0.1);
+      }
       body {
         margin: 0;
         font-family: sans-serif;
-        background-color: rgba(30, 30, 30, 0.8);
-        color: white;
+        background-color: var(--bg);
+        color: var(--text);
+        transition: background-color 0.2s;
       }
       #container {
         width: 300px;
         padding: 10px;
         transform: translateX(100%);
-        transition: transform 0.25s ease;
+        opacity: 0;
+        transition: transform 0.25s ease, opacity 0.25s ease;
       }
       #container.show {
         transform: translateX(0);
+        opacity: 1;
       }
       input {
         width: 100%;
@@ -36,10 +49,31 @@
         cursor: pointer;
       }
       li:hover {
-        background-color: rgba(255, 255, 255, 0.1);
+        background-color: var(--hover);
+      }
+      li.selected {
+        background-color: var(--hover);
       }
       #chain-runner {
         margin-top: 10px;
+      }
+      #preview {
+        margin-top: 8px;
+        font-size: 12px;
+        opacity: 0.7;
+      }
+      #flash {
+        position: absolute;
+        bottom: 10px;
+        right: 10px;
+        background: var(--hover);
+        padding: 4px 8px;
+        border-radius: 4px;
+        opacity: 0;
+        transition: opacity 0.3s;
+      }
+      #flash.show {
+        opacity: 1;
       }
     </style>
   </head>
@@ -51,7 +85,9 @@
       <h3>Paste from History</h3>
       <ul id="history"></ul>
       <div id="chain-runner" style="display:none"></div>
+      <div id="preview"></div>
     </div>
+    <div id="flash">Copied!</div>
     <script src="overlay.js"></script>
   </body>
 </html>

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -16,6 +16,9 @@ contextBridge.exposeInMainWorld('api', {
   getClipboardHistory: () => ipcRenderer.invoke('get-clipboard-history'),
   pinClipboardItem: (id: string, pinned: boolean) =>
     ipcRenderer.invoke('pin-clipboard-item', id, pinned),
+  getSettings: () => ipcRenderer.invoke('get-settings'),
+  saveSettings: (s: any) => ipcRenderer.invoke('save-settings', s),
+  insertSnippet: (text: string) => ipcRenderer.invoke('insert-snippet', text),
   hideOverlay: () => ipcRenderer.send('hide-overlay'),
   getErrorLog: () => ipcRenderer.invoke('get-error-log'),
   exportDiagnostics: () => ipcRenderer.invoke('export-diagnostics'),

--- a/packages/desktop/src/settings.ts
+++ b/packages/desktop/src/settings.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+export interface Settings {
+  overlaySide: 'left' | 'right';
+  theme: 'light' | 'dark';
+  overlayX?: number;
+  overlayY?: number;
+}
+
+const DIR = join(homedir(), '.snipflow');
+const FILE = join(DIR, 'settings.json');
+let settings: Settings = { overlaySide: 'right', theme: 'dark' };
+
+export function loadSettings(): Settings {
+  try {
+    if (existsSync(FILE)) {
+      const data = JSON.parse(readFileSync(FILE, 'utf-8')) as Partial<Settings>;
+      settings = { ...settings, ...data } as Settings;
+    }
+  } catch {}
+  return settings;
+}
+
+export function saveSettings(update: Partial<Settings>): Settings {
+  settings = { ...settings, ...update };
+  if (!existsSync(DIR)) mkdirSync(DIR, { recursive: true });
+  writeFileSync(FILE, JSON.stringify(settings, null, 2));
+  return settings;
+}
+
+export function getSettings(): Settings {
+  return settings;
+}

--- a/packages/desktop/src/types.ts
+++ b/packages/desktop/src/types.ts
@@ -10,6 +10,9 @@ export interface SnippetApi {
   getChainByName(name: string): Promise<any>;
   getClipboardHistory(): Promise<{ id: string; content: string; timestamp: number; pinned: number }[]>;
   pinClipboardItem(id: string, pinned: boolean): Promise<any>;
+  getSettings(): Promise<any>;
+  saveSettings(s: any): Promise<any>;
+  insertSnippet(text: string): Promise<any>;
   hideOverlay(): void;
   getErrorLog(): Promise<string>;
   exportDiagnostics(): Promise<string>;


### PR DESCRIPTION
## Summary
- add automatic snippet insertion via OS paste commands
- persist user settings in `settings.json`
- expose settings and insertion APIs through preload
- style overlay with light/dark themes and copy feedback
- support keyboard navigation and preview in the overlay
- register global hotkey for overlay and save position on hide

## Testing
- `pnpm test` *(fails: request to https://registry.npmjs.org/prebuildify failed: cache mode is 'only-if-cached' but no cached response is available)*